### PR TITLE
More edits for grubby.8

### DIFF
--- a/grubby.8
+++ b/grubby.8
@@ -1,9 +1,10 @@
 .TH GRUBBY 8 "Tue Jan 18 2005"
 .SH NAME
-grubby \- command line tool used to configure bootloader menu entries across multiple architectures
+grubby \- command line tool used to configure bootloader menu entries across
+multiple architectures
 
 .SH SYNOPSIS
-\fBgrubby\fR [\fIOPTIONS...\fR]
+\fBgrubby\fR [\fIOPTIONS\fR]
 
 .SH DESCRIPTION
 \fBgrubby\fR is a command line tool for updating and displaying information
@@ -29,13 +30,13 @@ are deprecated in favor of previously mentioned bootloaders. The
 \fBSILO\fR bootloader should also be considered unsupported.
 
 .SS Default Behavior
-The default architecture is chosen at compile time. The grubby executable
-has a series of built in assumptions about what bootloader is being used and
-where its configuration file lives. If no output format option is specified
-on the command line then grubby will use these default settings to first
-search for an existing configuration and, if it is not found, assume that
-it should be placed in the standard location. These default assumptions are
-listed in the table below.
+The default bootloader target is primarily determined by the architecture
+for which grubby has been built.  Each architecture has a preferred
+bootloader, and each bootloader has its own configuration file.  If no
+bootloader is selected on the command line, grubby will use these default
+settings to search for an existing configuration.  If no bootloader
+configuration file is found, grubby will use the default value for that
+architecture.  These defaults are listed in the table below.
 
 .TS
 allbox;
@@ -72,19 +73,18 @@ Add a new boot entry for the kernel located at \fIkernel-path\fR. A title for
 the boot entry must be set using \fB-\-title\fR. Most invocations should also
 include \fB-\-initrd\fR with memtest86 as a notable exception.
 
-The \fB-\-update-kernel\fR
-option may not be used in the same invocation. 
+The \fB-\-update-kernel\fR option may not be used in the same invocation.
 
 .TP
 \fB-\-remove-kernel\fR=\fIkernel-path\fR
-Removes all boot entries which match \fIkernel-path\fR. This may be used
-along with \fB-\-add-kernel\fR, in which case the new kernel being added will
-never be removed.
+Remove all boot entries which match \fIkernel-path\fR. This may be used
+along with \fB-\-add-kernel\fR, in which case the new entry being added will
+not be removed.
 
 .TP
 \fB-\-update-kernel\fR=\fIkernel-path\fR
-The entries for kernels matching \fRkernel-path\fR are updated. Currently
-the only items that can be updated is the kernel argument list, which is
+Update the entries for kernels matching \fRkernel-path\fR. Currently
+the only item that can be updated is the kernel argument list, which is
 modified via the \fB-\-args\fR and \fB-\-remove-args\fR options.
 
 .TP
@@ -126,7 +126,7 @@ being added.
 
 .TP
 \fB-\-efi\fR
-Use linuxefi and initrdefi when constructing bootloader stanzas instead of linux and initrd.
+Use appropriate bootloader commands for EFI on this architecture.
 
 .TP
 \fB-\-set-default\fR=\fIkernel-path\fR
@@ -178,16 +178,18 @@ Display information on all boot entries which match \fIkernel-path\fR. I
 
 .TP
 \fB-\-bootloader-probe\fR
+Attempt to probe for installed bootloaders.  If this option is specified,
 \fBgrubby\fR tries to determine if \fBgrub\fR or \fBlilo\fR is currently
-installed. When one of those bootloaders is found the name of that bootloader
-is displayed on stdout.  Both could be installed (on different devices), and
-grubby will print out the names of both bootloaders, one per line. The probe
-for \fBgrub\fR requires a commented out boot directive \fBgrub.conf\fR
-identical to the standard directive in the lilo configuration file. If this
-is not present \fBgrubby\fR will assume grub is not installed (note
-that \fBanaconda\fR places this directive in \fBgrub.conf\fR files it creates).
+installed. When one of those bootloaders is found the name of that
+bootloader is displayed on stdout.  Both could be installed (on different
+devices), and grubby will print out the names of both bootloaders, one per
+line. The probe for \fBgrub\fR requires a commented out boot directive
+\fBgrub.conf\fR identical to the standard directive in the lilo
+configuration file. If this is not present \fBgrubby\fR will assume grub is
+not installed (note that \fBanaconda\fR places this directive in
+\fBgrub.conf\fR files it creates).
 
-\fIThis option is only available on i386 platforms.\fR
+\fIThis option is only available on x86 BIOS platforms.\fR
 
 .TP
 \fB-v\fR, \fB-\-version\fR
@@ -202,7 +204,8 @@ alternative bootloader.
 
 .TP
 \fB-\-elilo\fR
-Use an \fBelilo\fR style configuration file. This is the default on ia64 platforms. This format is deprecated.
+Use an \fBelilo\fR style configuration file. This is the default on ia64
+platforms. This format is deprecated.
 
 .TP
 \fB-\-extlinux\fR
@@ -210,13 +213,14 @@ Use an \fBextlinux\fR style configuration file. This format is deprecated.
 
 .TP
 \fB-\-grub\fR
-Use a \fBgrub\fR style configuration file. This is the default on ia32 platforms.
+Use a \fBgrub\fR style configuration file. This is the default on the i386
+architecture.
 
 .TP
 \fB-\-grub2\fR
-Use a \fBgrub2\fR style configuration file. This is the default on \fBx86_64\fR
-architecture as well as the \fBppc64\fR and \fBppc64le\fR architectures
-running on Power8 or later hardware.
+Use a \fBgrub2\fR style configuration file. This is the default on
+\fBx86_64\fR architecture as well as the \fBppc64\fR and \fBppc64le\fR
+architectures running on Power8 or later hardware.
 
 .TP
 \fB-\-lilo\fR
@@ -224,7 +228,8 @@ Use a \fBlilo\fR style configuration file.
 
 .TP
 \fB-\-silo\fR
-Use a \fBsilo\fR style configuration file. This is the default on SPARC systems. This format is legacy, deprecated, and unsupported.
+Use a \fBsilo\fR style configuration file. This is the default on SPARC
+systems. This format is legacy, deprecated, and unsupported.
 
 .TP
 \fB-\-yaboot\fR
@@ -275,9 +280,9 @@ directive found in the template stanza.
 
 .TP
 \fB-\-devtreedir\fR=\fIfile_path\fR
-Use the specified \fIfile path\fR to load the devicetree definition. This is for
-platforms where a flat file is used instead of firmware to instruct the kernel
-how to communicate with devices.
+Use the specified \fIfile path\fR to load the devicetree definition. This is
+for platforms where a flat file is used instead of firmware to instruct the
+kernel how to communicate with devices.
 
 .SH MULTIBOOT OPTIONS
 The Multiboot Specification provides a generic interface for boot
@@ -327,12 +332,13 @@ kernel_args	Set of arguments for the kernel
 menu_index	Index number of a menu entry
 .TE
 
-The examples below quote strings that may have spaces or other whitespace in them. It is also
-perfectly valid to backslash escape these strings if that is more convenient.
+The examples below quote strings that may have spaces or other whitespace in
+them. It is also perfectly valid to backslash escape these strings if that
+is more convenient.
 
 .PP
-Add a new kernel entry and copy all options from the current default kernel. This is the behavior
-that most users will want.
+Add a new kernel entry and copy all options from the current default kernel.
+This is the behavior that most users will want.
 .IP
 \fBgrubby\fR --add-kernel=\fInew_kernel\fR --title="\fIentry_title\fR" --initrd="\fInew_initrd\fR" --copy-default
 .PP
@@ -344,13 +350,15 @@ Remove \fBall menu entries\fR for a specified kernel.
 .IP
 \fBgrubby\fR --remove-kernel=\fIold_kernel\fR
 .PP
-Target a single menu entry to remove without targetting other entries with the same kernel.
+Target a single menu entry to remove without targetting other entries with
+the same kernel.
 .IP
 \fBgrubby\fR --info=\fIold_kernel\fR
 
 \fBgrubby\fR --remove-kernel=\fImenu_index\fR
 .PP
-Update the arguments for all entries of a specific kernel. New arguments get added while existing arguments get updated values.
+Update the arguments for all entries of a specific kernel. New arguments get
+added while existing arguments get updated values.
 .IP
 \fBgrubby\fR --update-kernel=\fIcurrent_kernel\fR --args="\fIkernel_args\fR"
 .PP


### PR DESCRIPTION
- Don't switch between the passive and active voice between the option
  descriptions
- keep the same point of view between options ("[it] removes all
  entries" vs "remove all entries")
- line wrap everywhere except the example envocations at <80 columns,
  not 100.
- consistent use of i386 vs ia32

Signed-off-by: Peter Jones pjones@redhat.com
